### PR TITLE
add env.sh

### DIFF
--- a/README
+++ b/README
@@ -9,31 +9,24 @@ To install the dispatcher library::
     $ git clone git@github.com:snoplus/disp.git
     $ cd disp
     $ make
+    $ source env.sh
 
 Running the Dispatcher
 ----------------------
 
 To run the dispatcher, simply run::
 
-    $ disp/bin/dispatch
+    $ dispatch
 
 To run the dispatcher as a daemon::
 
-    $ nohup disp/bin/dispatch &>[path/to/logfile] &
+    $ nohup dispatch &>[path/to/logfile] &
 
 Reading from the Dispatcher
 ---------------------------
 
 You can read events from the dispatch stream
-using the python module dispatch. First, add
-the python directory to your PYTHONPATH environment
-variable and the lib directory to your
-LD_LIBRARY_PATH environment variable::
-
-    $ export PYTHONPATH=[/path/to/disp]/python:$PYTHONPATH
-    $ export LD_LIBRARY_PATH=[/path/to/disp]/lib:$LD_LIBRARY_PATH
-
-and then `import dispatch`. For example::
+using the python module dispatch::
 
     >>> from dispatch import *
     >>> d = Dispatch('localhost')

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,4 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PATH=$DIR/bin:$PATH
+export LD_LIBRARY_PATH=$DIR/lib:$LD_LIBRARY_PATH
+export PYTHONPATH=$DIR/python:$PYTHONPATH


### PR DESCRIPTION
Add a env.sh file which adds the disp package bin directory to PATH, the lib directory to LD_LIBRARY_PATH, and the python directory to PYTHONPATH. Update README to add "source env.sh".
